### PR TITLE
added Jekyll-Maps plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@
 
 ### Plugins
 - [Jekyll-IIIF plugin](https://github.com/pbinkley/jekyll-iiif)
+- [Jekyll-Maps plugin](https://github.com/ayastreb/jekyll-maps)
 
 ### Themes
 - [Wax: a gem-packaged Jekyll theme for creating minimal exhibitions with Jekyll, IIIF, and ElasticLunr.js](https://github.com/minicomp/wax)


### PR DESCRIPTION
Adds a link to the Jekyll-maps plugin to the Jekyll Plugins section of the readme.
https://github.com/ayastreb/jekyll-maps

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/hardyoyo/awesome-static-digital-libraries/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆