### PR TITLE
Adding Red, White and Black to the Projects Section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@
 
 ### Themes
 - [Wax: a gem-packaged Jekyll theme for creating minimal exhibitions with Jekyll, IIIF, and ElasticLunr.js](https://github.com/minicomp/wax)
+- [Jekyll Academic](https://github.com/ncsu-libraries/jekyll-academic): a Jekyll template developed by NCSU Libraries tailored specifically for use within the academic community.
 
 ### Other Awesome Lists
 - [Awesome Static Generators](https://github.com/myles/awesome-static-generators)

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@
 - [staticAid](http://hillelarnold.com/staticAid/)
 - [The Biggert Collection of Architectural Vignettes](https://cul.github.io/biggert_static/search/)
 - [The Barbara Curtis Adachi Bunraku Collection](http://bunraku.library.columbia.edu/)
+- [Red, White & Black](https://scrc.lib.ncsu.edu/m/exhibits/redwhiteblack/)
 
 ## Resources
 


### PR DESCRIPTION
Adding the Red, White & Black site (https://scrc.lib.ncsu.edu/m/exhibits/redwhiteblack/) to the projects list. This site makes use of the jekyll-maps plugin to display locations of historically significant events on the NC State campus. 

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/hardyoyo/awesome-static-digital-libraries/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
