### PR TITLE
adding the Red, White and Black project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@
 - [staticAid](http://hillelarnold.com/staticAid/)
 - [The Biggert Collection of Architectural Vignettes](https://cul.github.io/biggert_static/search/)
 - [The Barbara Curtis Adachi Bunraku Collection](http://bunraku.library.columbia.edu/)
+- [Red, White & Black](https://scrc.lib.ncsu.edu/m/exhibits/redwhiteblack/)
 
 ## Resources
 


### PR DESCRIPTION
Adding [Red, White & Black](https://scrc.lib.ncsu.edu/m/exhibits/redwhiteblack/) to the projects section. This project uses the Jekyll-Maps plugin to display the locations of events of historical significance on the NC State campus. 

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/hardyoyo/awesome-static-digital-libraries/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
